### PR TITLE
isolates $nlBurger and $nlDrawer usage.

### DIFF
--- a/devel/ng-nlFramework.js
+++ b/devel/ng-nlFramework.js
@@ -103,6 +103,8 @@ angular.module('nlFramework', [])
       animation: 'ease',
       // use action button
       actionButton: false,
+      // use burger button
+      burgerButton: false,
       // use toast messages
       toast: false,
       // use three dot menu
@@ -330,7 +332,7 @@ angular.module('nlFramework', [])
           nlDrawer.hide();
         });
 
-        if($nlConfig.options.burger){
+        if($nlConfig.options.burgerButton && $nlConfig.options.burger){
           $nlElements.burgerH.on("tap", function(ev) {
             if( !$nlElements.burger.hasAttribute("ng-click") ){
               nlDrawer.toggle();

--- a/devel/ng-nlFramework.js
+++ b/devel/ng-nlFramework.js
@@ -360,7 +360,7 @@ angular.module('nlFramework', [])
       // set open state and toggle burger
       nlDrawer.openned = true;
       $nlConfig.options.reverse = true;
-      if( $nlConfig.options.burger ) $nlBurger.toggle(true);
+      if( $nlConfig.options.burgerButton && $nlConfig.options.burger ) $nlBurger.toggle(true);
       setTimeout( function () {
         nlDrawer.on.show();
       }, $nlConfig.options.speed*1000)
@@ -374,7 +374,7 @@ angular.module('nlFramework', [])
       $nlElements.drawerDimm.style.visibility = 'hidden';
       $nlElements.drawerDimm.style.opacity = '0';
       // toggle burger
-      if ( nlDrawer.openned || $nlConfig.options.burger){
+      if ( $nlConfig.options.burgerButton && (nlDrawer.openned || $nlConfig.options.burger) ){
         $nlBurger.toggle(false);
       }
       // set open state


### PR DESCRIPTION
If I want to use `$nlDrawer` directive without `$nlBurger`, there was an error, because the app tries to register a **tap** event on a not existing nlBurger element. It happens because, when merging default options and my custom options, the nlBurger is configured without I expecting.

My proposal is to add a **burgerButton** option, like you do with **actionButton**, so you can use this directive by adding the id on the required element and the option `burgerButton: true`.

Another option would be only active burger button when there's configs set to it **and** there's an element with `id="nlBurger"`. I did not suggest that because I think it can be a little buggy (this strategy will not show an error on console, so we would put users on hard time to find that they have forgotten to add the required id).
